### PR TITLE
Joblib deprecation and trimming down the layer size.

### DIFF
--- a/Lab 1 - Lambda and SciKit Learn Inference/README.md
+++ b/Lab 1 - Lambda and SciKit Learn Inference/README.md
@@ -133,6 +133,7 @@ We recommend you use the latest version of Firefox or Chrome to complete this wo
     pipenv --python 3.6
     pipenv install mock PyHamcrest
     pipenv install sklearn
+    pipenv install joblib
     ls $VIRTUAL_ENV
     PY_DIR='build/python/lib/python3.6/site-packages'
     mkdir -p $PY_DIR
@@ -140,6 +141,8 @@ We recommend you use the latest version of Firefox or Chrome to complete this wo
     pip install -r requirements.txt --no-deps -t $PY_DIR
     cd build/
     find . -name "*.so" | xargs strip
+    find . -type d -name "tests" -exec rm -rfv {} +
+    find . -type d -name "__pycache__" -exec rm -rfv {} +
     7z a -mm=Deflate -mfb=258 -mpass=15 -r ../SentimentAnalysis_Layers.zip *
     cd ..
     rm -r build/

--- a/Lab 1 - Lambda and SciKit Learn Inference/lambda_function.py
+++ b/Lab 1 - Lambda and SciKit Learn Inference/lambda_function.py
@@ -2,7 +2,7 @@ import json
 import boto3
 import warnings
 from sklearn.feature_extraction.text import CountVectorizer
-from sklearn.externals import joblib
+import joblib
 
 warnings.filterwarnings(action='ignore', category=Warning) 
 s3 = boto3.resource('s3')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Joblib has been deprecated from sklearn, so import it directly.
2. The current layer is about 54MB after using 7zip, which is too large. Need to delete the "tests" and "__pycache__" directories prior to 7zip which makes it about 40MB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
